### PR TITLE
Windows support

### DIFF
--- a/notebones/src/graveyard/grave.rs
+++ b/notebones/src/graveyard/grave.rs
@@ -12,6 +12,7 @@ pub trait Grave {
     fn create_tunnel(source_file: &Path, lnk_name: &Path) -> Result<()>;
 
     /// view symlinks
+    #[cfg(not(target_os = "windows"))]
     fn peek_tunnel(path: &Path) -> Result<()>;
 
     /// rename notes without having to interact with the bones path

--- a/notebones/src/graveyard/gravekeeper.rs
+++ b/notebones/src/graveyard/gravekeeper.rs
@@ -16,7 +16,7 @@ pub fn spawn_bones_editor(bones_editor: &str, fpath: &Path) {
 
 /// this is currently unsupported
 #[cfg(target_os = "windows")]
-pub fn spawn_bones_editor(bones_editor: &str, fpath: String) {
+pub fn spawn_bones_editor(bones_editor: &str, fpath: &Path) {
     Command::new(bones_editor)
         .arg(fpath)
         .spawn()

--- a/notebones/src/main.rs
+++ b/notebones/src/main.rs
@@ -1,7 +1,6 @@
 mod context;
 mod graveyard;
 use crate::graveyard::grave::Grave;
-use clap::*;
 use std::{
     io,
     path::Path,
@@ -10,7 +9,7 @@ use std::{
 };
 
 impl Grave for Path {
-
+    #[cfg(not(target_os = "windows"))]
     fn create_tunnel(source_file: &Path, lnk_name: &Path) -> io::Result<()> {
        match std::os::unix::fs::symlink(source_file, lnk_name) {
             Ok(_) => Ok(()),
@@ -18,6 +17,7 @@ impl Grave for Path {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn peek_tunnel(path: &Path) -> io::Result<()> {
         let attr = fs::read_link(path).unwrap();
 
@@ -97,6 +97,4 @@ fn main() {
         // function defined by operating system at the top of the file
         graveyard::gravekeeper::spawn_bones_editor(&ctx.bones_editor, &fpath);
     }
-
-    panic!();
 }


### PR DESCRIPTION
Disables full symlink functionality on windows platform
Makes the program not crash after having opened the editor

Fixes #8 